### PR TITLE
Doc: support for Typst resources

### DIFF
--- a/content/en/wiki/raccolte-di-risorse/_index.md
+++ b/content/en/wiki/raccolte-di-risorse/_index.md
@@ -26,5 +26,5 @@ When contributing your resources or about to accept someone else's work, make su
 
 - not to upload/accept duplicate, incomprehensible, useless, offensive, or illegal content;
 - that all [automatic checks](./controlli-automatici) pass;
-- to use, where possible, "source" `.tex`/`.md`/`.doc(x)`/`.odt(x)` and similar files instead of their compiled PDF/HTML counterparts (and never unembedded images in other documents);
+- to use, where possible, "source" `.tex`/`.md`/`.typ`/`.doc(x)`/`.odt(x)` and similar files instead of their compiled PDF/HTML counterparts (and never unembedded images in other documents);
 - to upload, if possible, the resource itself rather than a link to an external version: this way, you enable other people to expand and correct it in the future.

--- a/content/en/wiki/raccolte-di-risorse/controlli-automatici.md
+++ b/content/en/wiki/raccolte-di-risorse/controlli-automatici.md
@@ -23,4 +23,4 @@ The rules in [prove.synta](https://github.com/csunibo/config/blob/main/prove.syn
 
 ## Compilation
 
-Any "source" files `.tex`/`.md`/`.doc(x)`/`.odt(x)` and similar must compile correctly into formats supported by CSUnibo.
+Any "source" files `.tex`/`.md`/`.typ`/`.doc(x)`/`.odt(x)` and similar must compile correctly into formats supported by CSUnibo.

--- a/content/it/wiki/raccolte-di-risorse/_index.md
+++ b/content/it/wiki/raccolte-di-risorse/_index.md
@@ -30,9 +30,9 @@ un'altra persona, assicurati:
 - di non caricare/accettare contenuti duplicati, incomprensibili, inutili,
   offensivi o illegali;
 - che tutti i [controlli automatici](./controlli-automatici) passino;
-- di usare, dove possibile, "sorgenti" `.tex`/`.md`/`.doc(x)`/`.odt(x)` e simili
-  anziché le loro controparti "compilate" PDF/HTML (e comunque mai immagini
-  non incorporate in altri documenti);
+- di usare, dove possibile, "sorgenti" `.tex`/`.md`/`.typ`/`.doc(x)`/`.odt(x)` e
+  simili anziché le loro controparti "compilate" PDF/HTML (e comunque mai
+  immagini non incorporate in altri documenti);
 - di caricare, se possibile, la risorsa stessa anziché un collegamento a una sua
   versione esterna: in questo modo rendi possibile ad altre persone ampliarla e
   correggerla in futuro.

--- a/content/it/wiki/raccolte-di-risorse/controlli-automatici.md
+++ b/content/it/wiki/raccolte-di-risorse/controlli-automatici.md
@@ -37,5 +37,5 @@ devono essere rispettate.
 
 ## Compilazione
 
-Eventuali file "sorgenti" `.tex`/`.md`/`.doc(x)`/`.odt(x)` e simili devono
-compilare correttamente nei formati supportati da CSUnibo.
+Eventuali file "sorgenti" `.tex`/`.md`/`.typ`/`.doc(x)`/`.odt(x)` e simili
+devono compilare correttamente nei formati supportati da CSUnibo.


### PR DESCRIPTION
Support for Typst resources (i.e., automatic compilation via CI/CD) was added by https://github.com/csunibo/config/pull/47. This PR documents such a feature.